### PR TITLE
Initalize the transaction ID to be the current timestamp.

### DIFF
--- a/mon.pl
+++ b/mon.pl
@@ -149,7 +149,7 @@ my $room = $matrix->start
 
 warn "Got room\n";
 
-my $next_txn_id;
+my $next_txn_id = time();
 
 my %txns;
 


### PR DESCRIPTION
We don't care that the transaction IDs move slower than real time; we only care
that when we restart we'll move forward to a new range of times (unless we're unlucky
and a clock jump causes us to jump back into the same starting timestamps as we
used earlier - though this much reduces that risk.)