### PR TITLE
Room version 6 enforces canonical json for events where JSON numbers …

### DIFF
--- a/mon.pl
+++ b/mon.pl
@@ -166,7 +166,7 @@ $room->configure(
 
 sub ping
 {
-   my $txn_id = $next_txn_id++;
+   my $txn_id = 'm' . $next_txn_id++;
 
    my $txn = $txns{$txn_id} = Txn(
       my $recv_f = Future->new,


### PR DESCRIPTION
…must be integers. The CS spec also suggests that txIds should be strings.

Prefix the passed txId with 'm', the same as Element